### PR TITLE
Add Windows batch runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ Open `docs/help.md` for detailed instructions.
    repository and launch the application:
 
    ```bash
-   ./run/run.sh
+   ./run/run.sh       # macOS/Linux
+   ```
+   On Windows use:
+
+   ```cmd
+   run\run.bat
    ```
 
 The script creates a Python virtual environment under `backend/venv`, installs
@@ -34,5 +39,6 @@ changes from the Git repository before launching.
 
 ## Updating
 
-Running `./run/run.sh` again will pull the newest changes from the remote Git
-repository and restart the app. This provides an easy way to stay up to date.
+Running `./run/run.sh` (or `run\run.bat` on Windows) again will pull the newest
+changes from the remote Git repository and restart the app. This provides an
+easy way to stay up to date.

--- a/docs/help.md
+++ b/docs/help.md
@@ -15,7 +15,12 @@ For more details visit the official [nba_api project](https://github.com/swar/nb
 From the project root simply execute:
 
 ```bash
-./run/run.sh
+./run/run.sh       # macOS/Linux
+```
+On Windows use:
+
+```cmd
+run\run.bat
 ```
 
 This command downloads updates, installs all requirements and starts the

--- a/run/run.bat
+++ b/run/run.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal
+
+rem Helper script to run the NBA Desktop app on Windows.
+rem It updates the repository, installs dependencies and starts
+rem both the backend and frontend servers.
+
+set ROOT=%~dp0..
+cd /d %ROOT%
+
+echo Updating repository...
+call git pull --ff-only
+
+rem ----- Backend setup -----
+cd backend
+if not exist venv (
+    echo Creating Python virtual environment...
+    python -m venv venv
+)
+
+echo Installing Python dependencies...
+venv\Scripts\pip install -r requirements.txt
+
+rem ----- Frontend setup -----
+cd ..\frontend
+if not exist node_modules (
+    echo Installing Node dependencies...
+    npm install
+)
+
+rem ----- Start servers -----
+cd ..\backend
+start "NBA Backend" venv\Scripts\python app.py --port 5005
+cd ..\frontend
+start "NBA Frontend" npm run dev
+
+echo.
+echo Servers started. Close this window to stop them.
+pause
+endlocal


### PR DESCRIPTION
## Summary
- add a `run.bat` script to run the app on Windows
- document the Windows script in the README and help files

## Testing
- `python -m py_compile backend/app.py`
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d59c6e0508321b8f91d9b44ea6b83