### PR TITLE
Fix vite plugin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Open `docs/help.md` for detailed instructions.
    cd NBA-GUI
    ```
 
+   If you prefer running the frontend manually, install its Node
+   dependencies first:
+
+   ```bash
+   cd frontend
+   npm install
+   ```
+
 2. Run the helper script which will install all dependencies, update the
    repository and launch the application:
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -25,3 +25,11 @@ run\run.bat
 
 This command downloads updates, installs all requirements and starts the
 backend and frontend servers. Leave the terminal open while using the app.
+
+If you want to run the frontend alone, install its dependencies first:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "electron": "^27.0.0",
     "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "tailwindcss": "^3.4.0"


### PR DESCRIPTION
## Summary
- add `@vitejs/plugin-react` to frontend dependencies
- document how to install Node packages when launching the app manually

## Testing
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d5b476e68832188d5e89a4981b613