### PR TITLE
Convert to simple browser-based app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-# NBA Desktop App
+# NBA Stats Web Interface
 
-This project offers a user-friendly desktop application for exploring NBA statistics. It bundles a small Flask server with an Electron + React interface. Everything runs locally on your computer.
+This project provides a lightweight web application for exploring NBA statistics. A Flask backend serves a small webpage that runs entirely in your browser.
 
 ## Features
 - Fetch common stats like player logs and box scores
 - Interactive data grid with plain‑English labels
 - Built‑in charting: line, bar, heatmap and more
 - Export results to CSV, Excel, JSON or Parquet
-- Cross‑platform installers (MSI and DMG/PKG)
 
 Open `docs/help.md` for detailed instructions.
 
@@ -18,14 +17,6 @@ Open `docs/help.md` for detailed instructions.
    ```bash
    git clone <repository-url>
    cd NBA-GUI
-   ```
-
-   If you prefer running the frontend manually, install its Node
-   dependencies first:
-
-   ```bash
-   cd frontend
-   npm install
    ```
 
 2. Run the helper script which will install all dependencies, update the
@@ -40,10 +31,10 @@ Open `docs/help.md` for detailed instructions.
    run\run.bat
    ```
 
-The script creates a Python virtual environment under `backend/venv`, installs
-required Python packages as well as Node dependencies for the frontend and then
-starts both servers. On subsequent runs it will automatically fetch the latest
-changes from the Git repository before launching.
+   The script creates a Python virtual environment under `backend/venv`, installs
+the required packages and then starts the local server. Your default browser
+opens automatically. On subsequent runs it will pull the latest changes before
+launching.
 
 ## Updating
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -18,8 +18,9 @@ logging.basicConfig(
     format='%(levelname)s %(asctime)s %(message)s'
 )
 
-app = Flask(__name__)
-CORS(app, origins="http://localhost:*")
+STATIC_DIR = Path(__file__).resolve().parent.parent / 'web'
+app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path='')
+CORS(app)
 
 ENDPOINTS = []
 ENDPOINT_FILE = Path(__file__).with_name('endpoints.yaml')
@@ -31,6 +32,10 @@ if ENDPOINT_FILE.exists():
                 ENDPOINTS.append(line)
 
 CACHE = {}
+
+@app.get('/')
+def index():
+    return app.send_static_file('index.html')
 
 @lru_cache(maxsize=1)
 def endpoints_module():

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,4 +1,4 @@
-# NBA Desktop Help
+# NBA Stats Web Help
 
 Welcome! This guide explains how to fetch and visualize NBA statistics.
 
@@ -24,12 +24,5 @@ run\run.bat
 ```
 
 This command downloads updates, installs all requirements and starts the
-backend and frontend servers. Leave the terminal open while using the app.
-
-If you want to run the frontend alone, install its dependencies first:
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
+local Flask server. Your default browser will open automatically. Leave
+the terminal open while using the app.

--- a/nba_gui.py
+++ b/nba_gui.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Simple command line launcher for the NBA web app."""
+import argparse
+import webbrowser
+from backend.app import app
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='nba_gui')
+    sub = parser.add_subparsers(dest='cmd')
+    run_p = sub.add_parser('run', help='start the local web server')
+    run_p.add_argument('--port', type=int, default=5005)
+    args = parser.parse_args()
+
+    if args.cmd == 'run':
+        url = f'http://localhost:{args.port}/'
+        print(f'Serving on {url}')
+        webbrowser.open(url)
+        app.run(host='127.0.0.1', port=args.port)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/run/run.bat
+++ b/run/run.bat
@@ -1,9 +1,9 @@
 @echo off
 setlocal
 
-rem Helper script to run the NBA Desktop app on Windows.
+rem Helper script to run the NBA stats web interface on Windows.
 rem It updates the repository, installs dependencies and starts
-rem both the backend and frontend servers.
+rem the local Flask server.
 
 set ROOT=%~dp0..
 cd /d %ROOT%
@@ -21,20 +21,9 @@ if not exist venv (
 echo Installing Python dependencies...
 venv\Scripts\pip install -r requirements.txt
 
-rem ----- Frontend setup -----
-cd ..\frontend
-if not exist node_modules (
-    echo Installing Node dependencies...
-    npm install
-)
-
-rem ----- Start servers -----
-cd ..\backend
-start "NBA Backend" venv\Scripts\python app.py --port 5005
-cd ..\frontend
-start "NBA Frontend" npm run dev
-
+cd ..
+call backend\venv\Scripts\python nba_gui.py run
 echo.
-echo Servers started. Close this window to stop them.
+echo Application started. Close this window to stop it.
 pause
 endlocal

--- a/run/run.sh
+++ b/run/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Helper script to run the NBA Desktop app.
+# Helper script to run the NBA stats web interface.
 # It updates the repository, installs dependencies and launches
-# both the backend and frontend servers.
+# the local Flask server.
 
 set -euo pipefail
 
@@ -21,22 +21,5 @@ fi
 echo "Installing Python dependencies..."
 venv/bin/pip install -r requirements.txt
 
-# ----- Frontend setup -----
-cd "$ROOT/frontend"
-if [ ! -d node_modules ]; then
-    echo "Installing Node dependencies..."
-    npm install
-fi
-
-# ----- Start servers -----
-cd "$ROOT/backend"
-source venv/bin/activate
-python app.py --port 5005 &
-BACK_PID=$!
-
-cd "$ROOT/frontend"
-npm run dev &
-FRONT_PID=$!
-
-trap "kill $BACK_PID $FRONT_PID" EXIT
-wait
+cd "$ROOT"
+"$ROOT/backend/venv/bin/python" nba_gui.py run

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,65 @@
+(function(){
+  const q = (sel) => document.querySelector(sel);
+  const playerTab = q('#player');
+  const teamTab = q('#team');
+  const visualTab = q('#visual');
+  const playerData = [];
+  const teamData = [];
+
+  function show(tab){
+    [playerTab, teamTab, visualTab].forEach(t => t.classList.add('hidden'));
+    tab.classList.remove('hidden');
+  }
+
+  q('#tab-player').onclick = () => show(playerTab);
+  q('#tab-team').onclick = () => show(teamTab);
+  q('#tab-visual').onclick = () => show(visualTab);
+
+  async function runQuery(endpoint, params, store){
+    const resp = await fetch('/run', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({endpoint, params})
+    });
+    const json = await resp.json();
+    store.length = 0;
+    json.data.forEach(r => store.push(r));
+    return store;
+  }
+
+  function renderTable(data, table, filter){
+    const rows = data.filter(r => JSON.stringify(r).toLowerCase().includes(filter.value.toLowerCase()));
+    if(!rows.length){ table.innerHTML=''; return; }
+    const keys = Object.keys(rows[0]);
+    table.innerHTML = '<thead><tr>' + keys.map(k=>`<th>${k}</th>`).join('') + '</tr></thead>';
+    table.innerHTML += '<tbody>' + rows.map(r=>'<tr>' + keys.map(k=>`<td>${r[k]}</td>`).join('') + '</tr>').join('') + '</tbody>';
+  }
+
+  q('#player-run').onclick = async () => {
+    await runQuery('PlayerGameLog', {PlayerID: q('#player-id').value}, playerData);
+    renderTable(playerData, q('#player-table'), q('#filter'));
+  };
+
+  q('#team-run').onclick = async () => {
+    await runQuery('TeamGameLog', {TeamID: q('#team-id').value}, teamData);
+    renderTable(teamData, q('#team-table'), q('#filter-team'));
+  };
+
+  q('#filter').oninput = () => renderTable(playerData, q('#player-table'), q('#filter'));
+  q('#filter-team').oninput = () => renderTable(teamData, q('#team-table'), q('#filter-team'));
+
+  async function visualize(data){
+    const resp = await fetch('/visualize', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({chart: q('#chart-type').value, data})
+    });
+    const json = await resp.json();
+    q('#chart-img').src = 'data:image/png;base64,' + btoa(json.image);
+    show(visualTab);
+  }
+
+  q('#player-chart').onclick = () => visualize(playerData);
+  q('#team-chart').onclick = () => visualize(teamData);
+  q('#chart-refresh').onclick = () => visualize(playerData.length?playerData:teamData);
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>NBA Stats Web</title>
+<style>
+body { font-family: Arial, sans-serif; padding: 1em; }
+.hidden { display: none; }
+button { margin-right: 0.5em; }
+table { border-collapse: collapse; margin-top: 1em; }
+th, td { border: 1px solid #ccc; padding: 2px 4px; }
+</style>
+</head>
+<body>
+<h1>NBA Stats Web</h1>
+<div>
+<button id="tab-player">Player Stats</button>
+<button id="tab-team">Team Stats</button>
+<button id="tab-visual">Visualize</button>
+</div>
+<div id="player" class="tab">
+<div>
+<input id="player-id" placeholder="Player ID">
+<button id="player-run">Run</button>
+</div>
+<div>
+<input id="filter" placeholder="Filter rows">
+<button id="player-chart">Chart</button>
+</div>
+<table id="player-table"></table>
+</div>
+<div id="team" class="tab hidden">
+<div>
+<input id="team-id" placeholder="Team ID">
+<button id="team-run">Run</button>
+</div>
+<div>
+<input id="filter-team" placeholder="Filter rows">
+<button id="team-chart">Chart</button>
+</div>
+<table id="team-table"></table>
+</div>
+<div id="visual" class="tab hidden">
+<select id="chart-type">
+<option value="line">Line</option>
+<option value="scatter">Scatter</option>
+</select>
+<button id="chart-refresh">Refresh</button>
+<div><img id="chart-img" alt="chart"></div>
+</div>
+<script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static HTML/JS directly from Flask backend
- add lightweight CLI `nba_gui run`
- simplify run scripts
- update README and docs for web interface

## Testing
- `python3 -m py_compile backend/app.py nba_gui.py`
- `bash run/run.sh` *(fails: no git remote configured)*
- `python3 nba_gui.py run --port 5005` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d5d646f50832189e62817c7dd1ead