### PR TITLE
Fix missing CORS dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ seaborn
 plotly
 joblib
 pyyaml
+flask-cors


### PR DESCRIPTION
## Summary
- include `flask-cors` in backend requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5f49c1b88321bd6ef76c52d01193