### PR TITLE
Implement name search and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This project provides a lightweight web application for exploring NBA statistics
 - Interactive data grid with plain‑English labels
 - Built‑in charting: line, bar, heatmap and more
 - Export results to CSV, Excel, JSON or Parquet
+- Search players and teams by name with instant suggestions
+- Filter results using dates and a quick text search
 
 Open `docs/help.md` for detailed instructions.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pandas as pd
 from flask import Flask, request, jsonify, send_file, abort
 from flask_cors import CORS
+from nba_api.stats.static import players, teams
 
 LOG_DIR = Path.home() / '.nba_desktop_app' / 'logs'
 LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -112,6 +113,20 @@ def download(token):
     else:
         abort(400, description='Unknown format')
     return send_file(tmp_path, as_attachment=True)
+
+
+@app.get('/search/player/<name>')
+def search_player(name: str):
+    """Return basic player info for a name search."""
+    matches = players.find_players_by_full_name(name)
+    return jsonify(matches)
+
+
+@app.get('/search/team/<name>')
+def search_team(name: str):
+    """Return basic team info for a name search."""
+    matches = teams.find_teams_by_full_name(name)
+    return jsonify(matches)
 
 
 def main():

--- a/docs/help.md
+++ b/docs/help.md
@@ -3,10 +3,11 @@
 Welcome! This guide explains how to fetch and visualize NBA statistics.
 
 1. Select a feature from the sidebar.
-2. Fill out the form with player or team names.
+2. Search for a player or team by name and pick the desired result.
 3. Click **Run** to fetch data. Results appear in the grid.
-4. Switch to **Visualize** to create charts.
-5. Use **Downloads** to save data in various formats.
+4. Use the date pickers and text filter to narrow rows.
+5. Switch to **Visualize** to create charts.
+6. Use **Downloads** to save data in various formats.
 
 For more details visit the official [nba_api project](https://github.com/swar/nba_api).
 

--- a/frontend/src/renderer/App.tsx
+++ b/frontend/src/renderer/App.tsx
@@ -7,6 +7,12 @@ export default function App() {
   const [tab, setTab] = useState<'player' | 'team' | 'visualize'>('player')
   const [playerId, setPlayerId] = useState('')
   const [teamId, setTeamId] = useState('')
+  const [playerName, setPlayerName] = useState('')
+  const [teamName, setTeamName] = useState('')
+  const [playerResults, setPlayerResults] = useState<any[]>([])
+  const [teamResults, setTeamResults] = useState<any[]>([])
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
   const [playerData, setPlayerData] = useState<Row[]>([])
   const [teamData, setTeamData] = useState<Row[]>([])
   const [filter, setFilter] = useState('')
@@ -27,6 +33,20 @@ export default function App() {
     set(json.data as Row[])
   }
 
+  async function searchPlayer() {
+    if (!playerName) return
+    const resp = await fetch(`http://localhost:${port}/search/player/${encodeURIComponent(playerName)}`)
+    const json = await resp.json()
+    setPlayerResults(json)
+  }
+
+  async function searchTeam() {
+    if (!teamName) return
+    const resp = await fetch(`http://localhost:${port}/search/team/${encodeURIComponent(teamName)}`)
+    const json = await resp.json()
+    setTeamResults(json)
+  }
+
   async function visualize(data: Row[]) {
     const resp = await fetch(`http://localhost:${port}/visualize`, {
       method: 'POST',
@@ -38,10 +58,25 @@ export default function App() {
     setTab('visualize')
   }
 
-  const shownPlayer = playerData.filter(r =>
-    JSON.stringify(r).toLowerCase().includes(filter.toLowerCase()))
-  const shownTeam = teamData.filter(r =>
-    JSON.stringify(r).toLowerCase().includes(filter.toLowerCase()))
+  function dateInRange(d: string) {
+    if (!d) return true
+    const val = new Date(d)
+    if (startDate && val < new Date(startDate)) return false
+    if (endDate && val > new Date(endDate)) return false
+    return true
+  }
+
+  const shownPlayer = playerData.filter(r => {
+    const txtOk = JSON.stringify(r).toLowerCase().includes(filter.toLowerCase())
+    const dateOk = dateInRange(r.GAME_DATE)
+    return txtOk && dateOk
+  })
+
+  const shownTeam = teamData.filter(r => {
+    const txtOk = JSON.stringify(r).toLowerCase().includes(filter.toLowerCase())
+    const dateOk = dateInRange(r.GAME_DATE)
+    return txtOk && dateOk
+  })
 
   return (
     <div className="p-4">
@@ -56,6 +91,13 @@ export default function App() {
         <div>
           <div className="mb-2">
             <input
+              value={playerName}
+              onChange={e => setPlayerName(e.target.value)}
+              className="border p-1 mr-2"
+              placeholder="Player name"
+            />
+            <button onClick={searchPlayer} className="px-2 py-1 border mr-2">Search</button>
+            <input
               value={playerId}
               onChange={e => setPlayerId(e.target.value)}
               className="border p-1 mr-2"
@@ -65,6 +107,17 @@ export default function App() {
               onClick={() => runQuery('PlayerGameLog', { PlayerID: playerId }, setPlayerData)}
               className="px-2 py-1 border"
             >Run</button>
+            {playerResults.length > 0 && (
+              <div className="mt-2 border bg-white shadow absolute z-10">
+                {playerResults.map(p => (
+                  <button
+                    key={p.id}
+                    onClick={() => { setPlayerId(String(p.id)); setPlayerName(p.full_name); setPlayerResults([]) }}
+                    className="block text-left w-full px-2 py-1 hover:bg-gray-100"
+                  >{p.full_name}</button>
+                ))}
+              </div>
+            )}
           </div>
           <div className="mb-2">
             <input
@@ -77,6 +130,18 @@ export default function App() {
               className="ml-2 px-2 py-1 border"
               onClick={() => visualize(shownPlayer)}
             >Chart</button>
+            <input
+              type="date"
+              value={startDate}
+              onChange={e => setStartDate(e.target.value)}
+              className="ml-2 border p-1"
+            />
+            <input
+              type="date"
+              value={endDate}
+              onChange={e => setEndDate(e.target.value)}
+              className="ml-2 border p-1"
+            />
           </div>
           <table className="text-sm">
             <thead>
@@ -99,6 +164,13 @@ export default function App() {
         <div>
           <div className="mb-2">
             <input
+              value={teamName}
+              onChange={e => setTeamName(e.target.value)}
+              className="border p-1 mr-2"
+              placeholder="Team name"
+            />
+            <button onClick={searchTeam} className="px-2 py-1 border mr-2">Search</button>
+            <input
               value={teamId}
               onChange={e => setTeamId(e.target.value)}
               className="border p-1 mr-2"
@@ -108,6 +180,17 @@ export default function App() {
               onClick={() => runQuery('TeamGameLog', { TeamID: teamId }, setTeamData)}
               className="px-2 py-1 border"
             >Run</button>
+            {teamResults.length > 0 && (
+              <div className="mt-2 border bg-white shadow absolute z-10">
+                {teamResults.map(t => (
+                  <button
+                    key={t.id}
+                    onClick={() => { setTeamId(String(t.id)); setTeamName(t.full_name); setTeamResults([]) }}
+                    className="block text-left w-full px-2 py-1 hover:bg-gray-100"
+                  >{t.full_name}</button>
+                ))}
+              </div>
+            )}
           </div>
           <div className="mb-2">
             <input
@@ -120,6 +203,18 @@ export default function App() {
               className="ml-2 px-2 py-1 border"
               onClick={() => visualize(shownTeam)}
             >Chart</button>
+            <input
+              type="date"
+              value={startDate}
+              onChange={e => setStartDate(e.target.value)}
+              className="ml-2 border p-1"
+            />
+            <input
+              type="date"
+              value={endDate}
+              onChange={e => setEndDate(e.target.value)}
+              className="ml-2 border p-1"
+            />
           </div>
           <table className="text-sm">
             <thead>


### PR DESCRIPTION
## Summary
- expose `/search/player/<name>` and `/search/team/<name>` APIs
- enable player/team lookup in the frontend
- add date and text filters to result tables
- document new behaviour

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6c545bec832186de65ac9db44b57